### PR TITLE
Update to 2.8.5

### DIFF
--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,7 +5,7 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-VERSION="1.5.14.67bf4e0edaaa"
+VERSION="2.8.5.e83816e33dfb"
 URL="http://sourceforge.net/projects/zurmo/files/zurmo-stable-${VERSION}.zip"
 
 dl $URL /usr/local/src

--- a/conf.d/main
+++ b/conf.d/main
@@ -44,7 +44,8 @@ EOF
 rm -f /etc/mysql/conf.d/force_utf8.cnf
 
 # configure apache
-a2dissite default
+#a2dissite default
+rm /etc/apache2/sites-enabled/*default*
 a2ensite zurmo
 a2enmod rewrite
 

--- a/overlay/usr/lib/inithooks/bin/zurmo.py
+++ b/overlay/usr/lib/inithooks/bin/zurmo.py
@@ -67,8 +67,8 @@ def main():
     m.execute('UPDATE zurmo._user SET hash=\"%s\" WHERE username=\"admin\";' % hash)
     '''
     
-    zurmo = "~/public_html/zurmo/app/protected/commands/zurmoc.php"
-    system("php %s changePassword --username=super --password=%s" % (zurmo, password))
+    zurmo = "/var/www/zurmo/app/protected/commands/zurmoc.php"
+    system("cd %s;zurmoc changePassword --username=admin --password=%s" % (zurmo, password))
 
     conf = "/var/www/zurmo/app/protected/config/perInstance.php"
     system("sed -i \"s|hostInfo.*|hostInfo'] = 'http://%s';|\" %s" % (domain, conf))

--- a/overlay/usr/lib/inithooks/bin/zurmo.py
+++ b/overlay/usr/lib/inithooks/bin/zurmo.py
@@ -60,10 +60,15 @@ def main():
     if domain == "DEFAULT":
         domain = DEFAULT_DOMAIN
 
+    '''
     hash = hashlib.md5(password).hexdigest()
 
     m = MySQL()
     m.execute('UPDATE zurmo._user SET hash=\"%s\" WHERE username=\"admin\";' % hash)
+    '''
+    
+    zurmo = "~/public_html/zurmo/app/protected/commands/zurmoc.php"
+    system("php %s changePassword --username=super --password=%s" % (zurmo, password))
 
     conf = "/var/www/zurmo/app/protected/config/perInstance.php"
     system("sed -i \"s|hostInfo.*|hostInfo'] = 'http://%s';|\" %s" % (domain, conf))

--- a/overlay/usr/lib/inithooks/bin/zurmo.py
+++ b/overlay/usr/lib/inithooks/bin/zurmo.py
@@ -67,8 +67,8 @@ def main():
     m.execute('UPDATE zurmo._user SET hash=\"%s\" WHERE username=\"admin\";' % hash)
     '''
     
-    zurmo = "/var/www/zurmo/app/protected/commands/zurmoc.php"
-    system("cd %s;zurmoc changePassword --username=admin --password=%s" % (zurmo, password))
+    zurmo = "/var/www/zurmo/app/protected/commands/"
+    system("cd %s;./zurmoc changePassword --username=admin --password=%s" % (zurmo, password))
 
     conf = "/var/www/zurmo/app/protected/config/perInstance.php"
     system("sed -i \"s|hostInfo.*|hostInfo'] = 'http://%s';|\" %s" % (domain, conf))

--- a/overlay/usr/lib/inithooks/bin/zurmo.py
+++ b/overlay/usr/lib/inithooks/bin/zurmo.py
@@ -60,12 +60,7 @@ def main():
     if domain == "DEFAULT":
         domain = DEFAULT_DOMAIN
 
-    '''
-    hash = hashlib.md5(password).hexdigest()
-
     m = MySQL()
-    m.execute('UPDATE zurmo._user SET hash=\"%s\" WHERE username=\"admin\";' % hash)
-    '''
     
     zurmo = "/var/www/zurmo/app/protected/commands/"
     system("cd %s;./zurmoc changePassword --username=admin --password=%s" % (zurmo, password))


### PR DESCRIPTION
Everything's updated and working however zurmo.py prints "Password changed" onscreen when setting password using zurmoc (line 66). I tried piping and not collecting data and piping to os.devnull to remove the message but ended up breaking something so here's the most recent version working even thought the "Password changed".

Also ignore the commits by "root", I forgot to set my git config while swapping between VMs.