### PR TITLE
Zurmo build fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,12 @@ and on top of that:
   password recovery).
 - Webmin modules for configuring Apache2, PHP, MySQL and Postfix.
 
+Supervised Manual Zurmo Update
+-------------------------------------------
+
+To upgrade to the latest version of Zurmo see `Upgrades`_ on the
+Zurmo website.
+
 Credentials *(passwords set at first boot)*
 -------------------------------------------
 
@@ -33,3 +39,4 @@ Credentials *(passwords set at first boot)*
 .. _Zurmo: http://zurmo.org/
 .. _TurnKey Core: https://www.turnkeylinux.org/core
 .. _Adminer: http://www.adminer.org/
+.. _Upgrades: http://zurmo.org/upgrades

--- a/changelog
+++ b/changelog
@@ -1,3 +1,9 @@
+turnkey-zurmo-14.1 (2) turnkey; urgency=low
+
+  * Upgraded to latest upstream version of Zurmo (3.1.1.7b482704bc58)
+
+ -- Stefan Davis <nafets.sivad@gmail.com>  Thu, 07 Apr 2016 03:33:28 +1000
+
 turnkey-zurmo-14.1 (1) turnkey; urgency=low
 
   * Installed security updates.

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -4,8 +4,7 @@ dl() {
     [ "$FAB_HTTP_PROXY" ] && PROXY="--proxy $FAB_HTTP_PROXY"
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
-
-VERSION="3.0.5.cf746baa61be"
+VERSION="3.1.1.7b482704bc58"
 URL="http://build.zurmo.com/downloads/zurmo-stable-${VERSION}.zip"
 
 dl $URL /usr/local/src


### PR DESCRIPTION
Fixed zurmo building, just updated the download to the newest stable because the old download was no longer hosted.